### PR TITLE
refactor: extended alias imports

### DIFF
--- a/db/config.ts
+++ b/db/config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'drizzle-kit';
+
 export const dbCredentials = {
   host: process.env.POSTGRES_HOST || '0.0.0.0',
   port: parseInt(process.env.POSTGRES_PORT || '5432'),

--- a/db/drop.ts
+++ b/db/drop.ts
@@ -1,5 +1,5 @@
 import { db } from '@/database.providers';
-import { users } from '@/users/users.schema';
+import { users } from '@users/users.model';
 import { getTableName } from 'drizzle-orm';
 import { exit } from 'process';
 // TODO: use react-ink

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -1,6 +1,6 @@
 import { exit } from 'process';
 import { db } from '@/database.providers';
-import { users } from '@/users/users.model';
+import { users } from '@users/users.model';
 import { faker } from '@faker-js/faker';
 
 console.log('Truncating the user database');

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,9 +6,9 @@ import {
   AuthorizationError,
   BadRequestError,
   ERROR_CODE_STATUS_MAP,
-} from '@/errors';
-import { usersPlugin } from '@/users/users.plugin';
-import { profilesPlugin } from '@/profiles/profiles.plugin';
+} from '@errors';
+import { usersPlugin } from '@users/users.plugin';
+import { profilesPlugin } from '@profiles/profiles.plugin';
 
 // the file name is in the spirit of NestJS, where app module is the device in charge of putting together all the pieces of the app
 // see: https://docs.nestjs.com/modules

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,9 +1,9 @@
 import * as jose from 'jose';
-import { env } from '@/config';
-import { UserInDb } from '@/users/users.schema';
+import { env } from '@config';
+import { UserInDb } from '@users/users.schema';
 import { Type } from '@sinclair/typebox';
 import { Value } from '@sinclair/typebox/value';
-import { AuthenticationError } from '@/errors';
+import { AuthenticationError } from '@errors';
 
 export class AuthService {
   private readonly ALG = env.JWT_ALGORITHM;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-import { DEFAULT, MapWithDefault } from '@/utils/defaultmap';
+import { DEFAULT, MapWithDefault } from '@utils/defaultmap';
 
 export class AuthenticationError extends Error {
   public status = 401;

--- a/src/profiles/profiles.module.ts
+++ b/src/profiles/profiles.module.ts
@@ -1,8 +1,8 @@
-import { AuthService } from '@/auth/auth.service';
+import { AuthService } from '@auth/auth.service';
 import { db } from '@/database.providers';
-import { ProfilesRepository } from '@/profiles/profiles.repository';
-import { ProfilesService } from '@/profiles/profiles.service';
-import { UsersRepository } from '@/users/users.repository';
+import { ProfilesRepository } from '@profiles/profiles.repository';
+import { ProfilesService } from '@profiles/profiles.service';
+import { UsersRepository } from '@users/users.repository';
 import { Elysia } from 'elysia';
 
 export const setupProfiles = () => {

--- a/src/profiles/profiles.plugin.ts
+++ b/src/profiles/profiles.plugin.ts
@@ -1,6 +1,6 @@
 import { Elysia } from 'elysia';
-import { setupProfiles } from '@/profiles/profiles.module';
-import { ReturnedProfileSchema } from '@/profiles/profiles.schema';
+import { setupProfiles } from '@profiles/profiles.module';
+import { ReturnedProfileSchema } from '@profiles/profiles.schema';
 
 export const profilesPlugin = new Elysia().use(setupProfiles).group(
   '/profiles/:username',

--- a/src/profiles/profiles.repository.ts
+++ b/src/profiles/profiles.repository.ts
@@ -1,6 +1,6 @@
 import { eq, and, sql } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import { users, userFollows } from '@/users/users.model';
+import { users, userFollows } from '@users/users.model';
 
 export class ProfilesRepository {
   constructor(private readonly db: PostgresJsDatabase) {}

--- a/src/profiles/profiles.schema.ts
+++ b/src/profiles/profiles.schema.ts
@@ -1,5 +1,5 @@
 import { Type } from '@sinclair/typebox';
-import { User, insertUserSchemaRaw } from '@/users/users.schema';
+import { User, insertUserSchemaRaw } from '@users/users.schema';
 
 export type Profile = Omit<
   User,

--- a/src/profiles/profiles.service.ts
+++ b/src/profiles/profiles.service.ts
@@ -1,7 +1,7 @@
 import { NotFoundError } from 'elysia';
-import { ProfilesRepository } from '@/profiles/profiles.repository';
-import { Profile } from '@/profiles/profiles.schema';
-import { UsersRepository } from '@/users/users.repository';
+import { ProfilesRepository } from '@profiles/profiles.repository';
+import { Profile } from '@profiles/profiles.schema';
+import { UsersRepository } from '@users/users.repository';
 
 export class ProfilesService {
   constructor(

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,7 +1,7 @@
-import { AuthService } from '@/auth/auth.service';
+import { AuthService } from '@auth/auth.service';
 import { db } from '@/database.providers';
-import { UsersRepository } from '@/users/users.repository';
-import { UsersService } from '@/users/users.service';
+import { UsersRepository } from '@users/users.repository';
+import { UsersService } from '@users/users.service';
 import { Elysia } from 'elysia';
 
 export const setupUsers = () => {

--- a/src/users/users.plugin.ts
+++ b/src/users/users.plugin.ts
@@ -1,11 +1,11 @@
 import { Elysia } from 'elysia';
-import { setupUsers } from '@/users/users.module';
+import { setupUsers } from '@users/users.module';
 import {
   InsertUserSchema,
   ReturnedUserSchema,
   UserLoginSchema,
   UpdateUserSchema,
-} from '@/users/users.schema';
+} from '@users/users.schema';
 
 export const usersPlugin = new Elysia()
   .use(setupUsers)

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -2,8 +2,8 @@
 // in charge of database interactions
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { eq } from 'drizzle-orm';
-import { UserToCreate, UserToUpdate } from '@/users/users.schema';
-import { users } from '@/users/users.model';
+import { UserToCreate, UserToUpdate } from '@users/users.schema';
+import { users } from '@users/users.model';
 
 export class UsersRepository {
   constructor(private readonly db: PostgresJsDatabase) {}

--- a/src/users/users.schema.ts
+++ b/src/users/users.schema.ts
@@ -1,7 +1,7 @@
 import { Type, Static } from '@sinclair/typebox';
 import { createInsertSchema, createSelectSchema } from 'drizzle-typebox';
 // Do not use path aliases here (i.e. '@/users/users.model'), as that doesn't work with Drizzle Studio
-import { users } from './users.model';
+import { users } from '@users/users.model';
 
 // Schema for inserting a user - can be used to validate API requests
 export const insertUserSchemaRaw = createInsertSchema(users);

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,10 +1,10 @@
 // users.service.ts
 // in charge of business logic - generate slug, fetch data from other services, cache something, etc.
 import { NotFoundError } from 'elysia';
-import { UsersRepository } from '@/users/users.repository';
-import { AuthService } from '@/auth/auth.service';
-import { UserInDb, UserToCreate, UserToUpdate } from '@/users/users.schema';
-import { AuthenticationError, BadRequestError } from '@/errors';
+import { UsersRepository } from '@users/users.repository';
+import { AuthService } from '@auth/auth.service';
+import { UserInDb, UserToCreate, UserToUpdate } from '@users/users.schema';
+import { AuthenticationError, BadRequestError } from '@errors';
 
 export class UsersService {
   constructor(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,12 @@
       /* Specify a set of entries that re-map imports to additional lookup locations. */
       "@db/*": ["./db/*"],
       "@/*": ["./src/*"],
-      "@users/*": ["./src/users/*"]
+      "@users/*": ["./src/users/*"],
+      "@auth/*": ["./src/auth/*"],
+      "@profiles/*": ["./src/profiles/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@errors": ["./src/errors.ts"],
+      "@config": ["./src/config.ts"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */


### PR DESCRIPTION
### Description

<!-- Provide a comprehensive description here about what your PR aims to solve. -->

This PR introduces _extended alias imports_, allowing imports such as:

```typescript
import users from '@users/users.model';`
```

instead of:

```typescript
import users from '@/users/users.model';`
```

<!-- You may also add additional context -->

This is something that we use at work and I thought it could be nice for this codebase.

What are your thoughts?

---

### PR Checklist (Please do not remove)

- [x] Read the [CONTRIBUTING](
  https://github.com/agnyz/elysia-realworld-example-app/blob/main/CONTRIBUTING.md) guide
- [x] Title this PR according to the `type(scope): description` or `type: description` format
- [x] Provide description sufficient to understand the changes introduced in this PR, and, if necessary, some screenshots
- [x] ~Reference an issue or discussion where the feature or changes have been previously discussed~
- [x] ~Add a failing test that passes with the changes introduced in this PR, or explain why it's not feasible~
- [x] ~Add documentation for the feature or changes introduced in this PR to the docs; you can run them with `bun docs`~
